### PR TITLE
link to schema from input types

### DIFF
--- a/docs/cms/components.adoc
+++ b/docs/cms/components.adoc
@@ -123,7 +123,7 @@ rendering engine is easy; here is how we do it.
 .Example controller with thymeleaf
 [source, javascript]
 ----
-var thymeleaf = require('/lib/xp/thymeleaf');
+var thymeleaf = require('/lib/thymeleaf');
 
 exports.get = function(req) {
 

--- a/docs/cms/input-types.adoc
+++ b/docs/cms/input-types.adoc
@@ -4,7 +4,8 @@
 :y: icon:check[role="green"]
 :n: icon:times[role="red"]
 
-This section lists all available input types available for XP schemas.
+This section lists all available input types available for XP schemas. + 
+This list only shows selector specific configuration. See <<schemas#input_types, schemas>> for configuration used by all input types. 
 
 == AttachmentUploader
 
@@ -559,7 +560,7 @@ image::Image-selector.png[Input box with a grid of images to select below it, 50
   </config>
 </input>
 ----
-<1> With the exception of `<allowContentTypes>` (which is not supported here) and `<allowPath>`, ImageSelector supports the same configuration options as <<ContentSelector>>.
+<1> With the exception of `<allowContentType>` (which is not supported here) and `<allowPath>`, ImageSelector supports the same configuration options as <<ContentSelector>>.
 <2> By default, Image Selector displays all images from the root. If you want to limit images to the same site, use `<allowPath>${site}/*</allowPath>`
 
 == Long
@@ -598,7 +599,7 @@ The MediaSelector is a specialized version of the <<ContentSelector>> that is li
   <label>My Media</label>
   <occurrences minimum="0" maximum="1"/>
   <config> <!--1-->
-    <allowContentTypes>media:archive</allowContentTypes>
+    <allowContentType>media:archive</allowContentType>
     <allowPath>${site}/*</allowPath> <!--2-->
     <treeMode>true</treeMode>
     <showStatus>true</showStatus>
@@ -606,7 +607,7 @@ The MediaSelector is a specialized version of the <<ContentSelector>> that is li
   </config>
 </input>
 ----
-<1> MediaSelector supports the same configuration options as <<ContentSelector>>, but is limited to using `media:*` content types in the `<allowContentTypes>` configuration.
+<1> MediaSelector supports the same configuration options as <<ContentSelector>>, but is limited to using `media:*` content types in the `<allowContentType>` configuration.
 <2> Just like <<ImageSelector>>, MediaSelector by default displays all media items starting from the content root.
 
 

--- a/docs/cms/schemas.adoc
+++ b/docs/cms/schemas.adoc
@@ -78,12 +78,12 @@ _@name_ is used when storing the data in a property, and must be unique on each 
 _@type_ refers to one of the many input types which are listed below.
 
 <2> *label* is another mandatory field that holds the human readable value that will be displayed when listing the input type control in the administrative interface +
-_@i18n_ is an optional attribute holding the key to localization phrase of the form (see <<schemas#schema_localization,localisation>>)
+_@i18n_ is an optional attribute holding the key to localization phrase of the form (see <<schemas#schema_localization,localisation>>).
 
-<3> *default* is an optional field that lets you specify default values to be used by the input type
+<3> *default* is an optional field that lets you specify default values to be used by the input type.
 
-<4> *help-text* is an optional text will be shown next to the input field and can be used for explanation of the field's purpose. +
-_@i18n_ is an optional attribute holding the key to localization phrase of the form (see <<schemas#schema_localization,localisation>>)
+<4> *help-text* is an optional field that lets you specify a text label shown below the input field. Used for explanation of the field's purpose. +
+_@i18n_ is an optional attribute holding the key to localization phrase of the form (see <<schemas#schema_localization,localisation>>).
 
 <5> *occurrences* is an optional field used to control the number of values stored by a single input. +
 _@minimum_ set to to zero means the input is not mandatory +

--- a/docs/framework/java-bridge.adoc
+++ b/docs/framework/java-bridge.adoc
@@ -7,8 +7,8 @@ JavaScript developers may directly invoke and use Java-based code, since the XP 
 
 == The `__` object
 
-In Enonic XP, there is a global object named ``__`` (double underscore), accessible from any serverside JavaScript code, which provides
-a way to wrap Java objects in a JavaScript object.  The ``__`` object has functions that allow JavaScript to communicate with Java
+In Enonic XP, there is a global object named `+__+` (double underscore), accessible from any serverside JavaScript code, which provides
+a way to wrap Java objects in a JavaScript object.  The `+__+` object has functions that allow JavaScript to communicate with Java
 classes. The ``newBean`` function will wrap the Java object named in the parameter, for instance:
 
 [source,javascript]

--- a/docs/variables.adoc
+++ b/docs/variables.adoc
@@ -1,2 +1,2 @@
 :release: 7
-:version: 7.2.1
+:version: 7.2.3


### PR DESCRIPTION
Input types page only cover the input type specific configuration. 
Linking to schema page containing the general configuration. 