### PR TITLE
Elaborate on the differences between dev mode and continuous builds

### DIFF
--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -98,7 +98,7 @@ Enonic XP can be run in a special mode known as _development mode_. In this mode
 
 Because of the way XP reads source files directly in development mode, it has a few limitations:
 
-- Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. For an overview over what JavaScript features you can use without compilation, see [these docs]
+- Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
 - XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (as per the previous point).
 
 If you need any of the above features, try using xref:build-system#_continuous_building[continuous build mode] instead.

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -94,7 +94,14 @@ NOTE:  XP apps deployed via file (locally) are presented with a small blue icon 
 As the name implies, development mode is intended only for development use and should _not_ be used in production. Doing so would cause both security and performance issues.
 ====
 
-Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect any changes to your project source files, including JavaScript controllers and XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
+Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect changes to your project source files, including JavaScript controllers and registered XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
+
+[NOTE]
+====
+Because of the way that XP works, some changes are not picked up in dev mode: if you add a _new_ content type, XP will not pick it up automatically. This is because content types are registered with XP when _deploying_ an app. However, changes to existing content types _are_ detected. If you'd like to have new content types picked up automatically, try using xref:build-system#_continuous_building[continuous build mode].
+
+This does not affect JavaScript controllers. You can add new controllers and they will be picked up by XP automatically.
+====
 
 Development mode also disables some of XP's caching mechanisms. To make the development workflow as smooth as possible, XP tries to invalidate caches for your static assets. This is to prevent you from getting stale resources so that what you see in the browser is always as up to date as possible.
 
@@ -113,7 +120,9 @@ Windows:: `$XP_INSTALL/bin/server.sh dev`
 Gradle also supports a https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build[continuous build mode].
 In continuous build mode, Gradle will monitor your project assets for changes and run a task you specify task when something changes.
 
-Continuous builds come in handy when the changes you're working on require a full compile and re-deploy, such as when you're working with Java or need to build/compile client-side assets with an external build tool (such as webpack).
+Continuous builds come in handy when the changes you're working on require a full compile and redeploy, such as when you're working with Java or need to build/compile client-side assets with an external build tool (such as webpack).
+
+Another use case for continuous builds is if you're adding _new_ content types (or other XML schemas?). Because these are registered when an app is deployed, you need to compile and redeploy your app for XP to become aware of them.
 
 If you don't need a full compile or don't need to run external build tools, you may be better served by using xref:build-system#_development_mode[XP's development mode].
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -98,8 +98,8 @@ Enonic XP can be run in a special mode known as _development mode_. In this mode
 
 Because of the way XP reads source files directly in development mode, it has a few limitations:
 
-. Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. For an overview over what JavaScript features you can use without compilation, see [these docs]
-. XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (per the previous point).
+- Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. For an overview over what JavaScript features you can use without compilation, see [these docs]
+- XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (as per the previous point).
 
 If you need any of the above features, try using xref:build-system#_continuous_building[continuous build mode] instead.
 
@@ -126,7 +126,7 @@ Another use case for continuous builds is if you're adding _new_ content types (
 
 If you don't need a full compile or don't need to run external build tools, you may be better served by using xref:build-system#_development_mode[XP's development mode].
 
-To use continuous builds, specify your task and pass the `--continuous` option. The following examples use the `deploy` task, but you can also use any other defined Gradle tasks:
+To use continuous Gradle tasks, specify your task and pass the `--continuous` option. The following examples use the `deploy` task, but you can also use any other defined Gradle tasks:
 
 Enonic CLI:: `enonic project gradle deploy --continuous`
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -119,7 +119,7 @@ Windows:: `$XP_INSTALL/bin/server.sh dev`
 === Continuous building
 
 Gradle also supports a https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build[continuous build mode].
-In continuous build mode, Gradle will monitor your project assets for changes and run a task you specify task when something changes.
+In continuous build mode, Gradle will monitor your project assets for changes and run a task you specify when something changes.
 
 Continuous builds come in handy when the changes you're working on require a full compile and redeploy, such as when you're working with Java or need to build/compile client-side assets with an external build tool (such as webpack).
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -104,7 +104,7 @@ NOTE: XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an ov
 +
 - XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (as per the previous point).
 
-If you need any of the above features, try using xref:build-system#_continuous_building[continuous build mode] instead.
+If development mode does not work for you, try using xref:build-system#_continuous_building[continuous build mode] instead.
 
 Development mode also disables some of XP's caching mechanisms. To make the development workflow as smooth as possible, XP tries to invalidate caches for your static assets. This is to prevent you from getting stale resources so that what you see in the browser is always as up to date as possible.
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -102,7 +102,6 @@ Because of the way XP reads source files directly in development mode, it has a 
 +
 NOTE: XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
 +
-- XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (as per the previous point).
 
 If development mode does not work for you, try using xref:build-system#_continuous_building[continuous build mode] instead.
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -105,16 +105,20 @@ Windows:: `$XP_INSTALL/bin/server.sh dev`
 === Continuous building
 
 Gradle also supports a https://docs.gradle.org/current/userguide/command_line_interface.html#sec:continuous_build[continuous build mode].
-This will monitor your project assets for changes and run the specified task when something changes.
+In continuous build mode, Gradle will monitor your project assets for changes and run a task you specify task when something changes.
 
-To use this with the `deploy` task, simply run the following command:
+Continuous builds come in handy when the changes you're working on require a full compile and re-deploy, such as when you're working with Java or need to build/compile client-side assets with an external build tool (such as webpack).
+
+If you don't need a full compile or don't need to run external build tools, you may be better served by using xref:build-system#_development_mode[XP's development mode].
+
+To use continuous builds, specify your task and pass the `--continuous` option. The following examples use the `deploy` task, but you can also use any other defined Gradle tasks:
+
+Enonic CLI:: `enonic project gradle deploy --continuous`
 
 Linux/MacOS:: `./gradlew deploy --continuous`
 
 Windows:: `gradlew.bat deploy --continuous`
 
-This will deploy and reload the application on the server when something changes in your project.
-The continuous deployment mode is most useful when coding Java, or other changes that require a full compile and re-deploy.
 
 
 // ==  Debugging

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -98,7 +98,10 @@ Enonic XP can be run in a special mode known as _development mode_. In this mode
 
 Because of the way XP reads source files directly in development mode, it has a few limitations:
 
-- Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
+- Files that require any sort of compilation (including transpilation) are not detected unless you run a build process on the side. For instance, if you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up by default. To have XP detect them, run a separate build process on the side, such as either a xref:build-system#_continuous_building[continuous build] or a webpack build.
++
+NOTE: XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
++
 - XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (as per the previous point).
 
 If you need any of the above features, try using xref:build-system#_continuous_building[continuous build mode] instead.

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -89,12 +89,11 @@ NOTE:  XP apps deployed via file (locally) are presented with a small blue icon 
 
 === Development Mode
 
-Enonic XP supports a so-called Development mode.
-When running in this mode, XP will automatically source JavaScript controllers directly from your project folder.
+Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect any changes to your project source files, including JavaScript controllers and XML schemas. When it detects a change, XP will automatically build and redeploy your project for you.
 
-This may be convenient if you are developing with pure JavaScript and do not depend on build steps in your project.
+This may be convenient if your project does not rely on additional build steps such as JavaScript bundling. If you need to run arbitrary build tasks before deploying your project, check out xref:build-system#_continuous_building[the section on continuous builds].
 
-You may activate dev mode when starting XP as follows:
+To activate development mode, use one of the following commands to start your sandbox:
 
 Enonic CLI:: `enonic sandbox start --dev`
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -100,7 +100,7 @@ Because of the way XP reads source files directly in development mode, it has a 
 
 - Files that require any sort of compilation (including transpilation) are not detected unless you run a build process on the side. For instance, if you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up by default. To have XP detect them, run a separate build process on the side, such as either a xref:build-system#_continuous_building[continuous build] or a webpack build.
 +
-NOTE: XP uses the  Nashorn JavaScript engine for compiling JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
+NOTE: XP uses the  Nashorn JavaScript engine for executing JavaScript. For an overview over what JavaScript features Nashorn supports, see https://kangax.github.io/compat-table/es6/#nashorn1_8[this feature table].
 +
 
 If development mode does not work for you, try using xref:build-system#_continuous_building[continuous build mode] instead.

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -96,7 +96,7 @@ As the name implies, development mode is intended only for development use and s
 
 Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect any changes to your project source files, including JavaScript controllers and XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
 
-Development mode also disables some of XP's caching mechanisms. (What mechanisms and why?)
+Development mode also disables some of XP's caching mechanisms. To make the development workflow as smooth as possible, XP tries to invalidate caches for your static assets. This is to prevent you from getting stale resources so that what you see in the browser is always as up to date as possible.
 
 Running XP in development mode may be convenient if your project does not rely on additional build steps such as JavaScript bundling. If you need to run arbitrary build tasks before deploying your project, check out xref:build-system#_continuous_building[the section on continuous builds].
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -123,7 +123,6 @@ In continuous build mode, Gradle will monitor your project assets for changes an
 
 Continuous builds come in handy when the changes you're working on require a full compile and redeploy, such as when you're working with Java or need to build/compile client-side assets with an external build tool (such as webpack).
 
-Another use case for continuous builds is if you're adding _new_ content types (or other XML schemas?). Because these are registered when an app is deployed, you need to compile and redeploy your app for XP to become aware of them.
 
 If you don't need a full compile or don't need to run external build tools, you may be better served by using xref:build-system#_development_mode[XP's development mode].
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -94,14 +94,14 @@ NOTE:  XP apps deployed via file (locally) are presented with a small blue icon 
 As the name implies, development mode is intended only for development use and should _not_ be used in production. Doing so would cause both security and performance issues.
 ====
 
-Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect changes to your project source files, including JavaScript controllers and registered XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
+Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will try to detect changes to your project source files, including JavaScript controllers and registered XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
 
-[NOTE]
-====
-Because of the way that XP works, some changes are not picked up in dev mode: if you add a _new_ content type, XP will not pick it up automatically. However, changes to existing content types _are_ detected. If you'd like to have new content types picked up automatically, try using xref:build-system#_continuous_building[continuous build mode].
+Because of the way XP reads source files directly in development mode, it has a few limitations:
 
-This does not affect JavaScript controllers. You can add new controllers and they will be picked up by XP automatically.
-====
+. Files that require any sort of compilation (including transpilation) are not detected. If you use TypeScript or JavaScript features that XP doesn't support, these files won't be picked up. For an overview over what JavaScript features you can use without compilation, see [these docs]
+. XP will not pick up _new_ content types. If you add a new content type after your previous project deploy, XP will not be able to see it. However, changes to _existing_ content types _are_ picked up. XP will pick up new JavaScript controllers as long as it can run them without compilation (per the previous point).
+
+If you need any of the above features, try using xref:build-system#_continuous_building[continuous build mode] instead.
 
 Development mode also disables some of XP's caching mechanisms. To make the development workflow as smooth as possible, XP tries to invalidate caches for your static assets. This is to prevent you from getting stale resources so that what you see in the browser is always as up to date as possible.
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -89,9 +89,16 @@ NOTE:  XP apps deployed via file (locally) are presented with a small blue icon 
 
 === Development Mode
 
-Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect any changes to your project source files, including JavaScript controllers and XML schemas. When it detects a change, XP will automatically build and redeploy your project for you.
+[WARNING]
+====
+As the name implies, development mode is intended only for development use and should _not_ be used in production. Doing so would cause both security and performance issues.
+====
 
-This may be convenient if your project does not rely on additional build steps such as JavaScript bundling. If you need to run arbitrary build tasks before deploying your project, check out xref:build-system#_continuous_building[the section on continuous builds].
+Enonic XP can be run in a special mode known as _development mode_. In this mode, XP will detect any changes to your project source files, including JavaScript controllers and XML schemas. It does this by reading these files directly from their source locations instead of from the application `.jar` file.
+
+Development mode also disables some of XP's caching mechanisms. (What mechanisms and why?)
+
+Running XP in development mode may be convenient if your project does not rely on additional build steps such as JavaScript bundling. If you need to run arbitrary build tasks before deploying your project, check out xref:build-system#_continuous_building[the section on continuous builds].
 
 To activate development mode, use one of the following commands to start your sandbox:
 
@@ -100,7 +107,6 @@ Enonic CLI:: `enonic sandbox start --dev`
 Linux/MacOS:: `$XP_INSTALL/bin/server.sh dev`
 
 Windows:: `$XP_INSTALL/bin/server.sh dev`
-
 
 === Continuous building
 

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -98,7 +98,7 @@ Enonic XP can be run in a special mode known as _development mode_. In this mode
 
 [NOTE]
 ====
-Because of the way that XP works, some changes are not picked up in dev mode: if you add a _new_ content type, XP will not pick it up automatically. This is because content types are registered with XP when _deploying_ an app. However, changes to existing content types _are_ detected. If you'd like to have new content types picked up automatically, try using xref:build-system#_continuous_building[continuous build mode].
+Because of the way that XP works, some changes are not picked up in dev mode: if you add a _new_ content type, XP will not pick it up automatically. However, changes to existing content types _are_ detected. If you'd like to have new content types picked up automatically, try using xref:build-system#_continuous_building[continuous build mode].
 
 This does not affect JavaScript controllers. You can add new controllers and they will be picked up by XP automatically.
 ====

--- a/docs/apps/build-system.adoc
+++ b/docs/apps/build-system.adoc
@@ -107,7 +107,6 @@ If development mode does not work for you, try using xref:build-system#_continuo
 
 Development mode also disables some of XP's caching mechanisms. To make the development workflow as smooth as possible, XP tries to invalidate caches for your static assets. This is to prevent you from getting stale resources so that what you see in the browser is always as up to date as possible.
 
-Running XP in development mode may be convenient if your project does not rely on additional build steps such as JavaScript bundling. If you need to run arbitrary build tasks before deploying your project, check out xref:build-system#_continuous_building[the section on continuous builds].
 
 To activate development mode, use one of the following commands to start your sandbox:
 


### PR DESCRIPTION
This PR adds some extra details to the descriptions of dev mode and
continuous builds. In particular, it:
- elaborates on what dev mode does, saying that it also picks up
  changes to XML schemas
- specifies what sort of tasks you need continuous builds for

As always, any feedback is much appreciated, especially in regard to
factual inaccuracies and the like.
