### PR TITLE
Change label names in display-name-expression example.

### DIFF
--- a/docs/cms/content-types.adoc
+++ b/docs/cms/content-types.adoc
@@ -69,10 +69,10 @@ NOTE: Only simple input types may be used as variables, so input types like Html
   <display-name>Person</display-name>
   <display-name-expression>${firstName} ${lastName}</display-name-expression> <!--1-->
   <form>
-    <input name="firstname" type="TextLine">
+    <input name="firstName" type="TextLine">
       <label>First Name</label>
     </input>
-    <input name="lastname" type="TextLine">
+    <input name="lastName" type="TextLine">
       <label>Last Name</label>
     </input>
   </form>


### PR DESCRIPTION
This PR changes the label names to reflect the casing that's used
in the preceding paragraph and which is referenced in the display name
expression.

Closes #254.