### PR TITLE
Fix ContentTypeFilter heading level.

### DIFF
--- a/docs/cms/input-types.adoc
+++ b/docs/cms/input-types.adoc
@@ -178,7 +178,7 @@ All children of the current content's parent +
   <allowPath>../*</allowPath>
 ====
 
-===  ContentTypeFilter
+==  ContentTypeFilter
 
 A field for selecting a content type.
 


### PR DESCRIPTION
The ContentTypeFilter section was nested under the ContentSelector
section instead of being its own, separate section. This PR fixes that.

Relates to #256.