### PR TITLE
Add information about what happens to multi-occurrence fields when referenced by `display-name-expression`

### DIFF
--- a/docs/cms/content-types.adoc
+++ b/docs/cms/content-types.adoc
@@ -61,7 +61,7 @@ The localisation key must then be declared and localised in the resource bundle.
 It's possible to auto-generate display name based on values from form fields by using ES6 template literals.
 In the example below, the display name will consist of the values from the `firstName` and `lastName` fields, separated by a space.
 
-NOTE: Only simple input types may be used as variables, so input types like HtmlArea or CheckBox are not supported.
+NOTE: Only simple input types may be used as variables, so input types like HtmlArea or CheckBox are not supported. Additionally, if an input allows multiple occurrences, only the first occurrence will be used in the generated display name.
 
 [source,xml]
 ----

--- a/docs/cms/content-types.adoc
+++ b/docs/cms/content-types.adoc
@@ -59,7 +59,7 @@ The localisation key must then be declared and localised in the resource bundle.
 == Display name expressions
 
 It's possible to auto-generate display name based on values from form fields by using ES6 template literals.
-In the example below, display name will be combination of values from `firstName` and `lastName` fields, separated by a space.
+In the example below, the display name will consist of the values from the `firstName` and `lastName` fields, separated by a space.
 
 NOTE: Only simple input types may be used as variables, so input types like HtmlArea or CheckBox are not supported.
 


### PR DESCRIPTION
This PR adds information about what happens to multi-occurrence fields when they are referenced by `display-name-expression`. It does this by adding information to the note about supported input types.

Additionally, there's also a small wording tweak to the explanation of the example in the paragraph above.