### PR TITLE
Change AIM -> IAM

### DIFF
--- a/docs/iam.adoc
+++ b/docs/iam.adoc
@@ -11,7 +11,7 @@ Additionally, the NoSQL storage supports fine-grained access control mechanisms 
 
 
 == IAM Concepts
-XP AIM consists of three central concepts:
+XP IAM consists of three central concepts:
 
 === Principals
 Principals are object that can be given permissions.


### PR DESCRIPTION
The IAM chapter mentions XP AIM once. I reckon this is a typo, so I've changed it to IAM.