### PR TITLE
lib-admin invalid params #405

### DIFF
--- a/docs/api/lib-admin.adoc
+++ b/docs/api/lib-admin.adoc
@@ -69,7 +69,6 @@ An object with the following keys and their values:
 [grid="none"]
 |===
 | Name | Kind | Details
-| path | string | Optional Admin Tool URI prefix
 | type | string | Either `server` (server-relative URL) or `absolute`
 |===
 


### PR DESCRIPTION
`lib-admin` `getHomeToolUrl` function actually accepts `params` object with a single `type` property. `path` property is no longer used. See the [code](https://github.com/enonic/xp/blob/master/modules/lib/lib-admin/src/main/resources/lib/xp/admin.js#L101-L102).