### PR TITLE
Link to configuration page from mail-lib page

### DIFF
--- a/docs/api/lib-mail.adoc
+++ b/docs/api/lib-mail.adoc
@@ -24,6 +24,10 @@ const mailLib = require('/lib/xp/mail');
 
 You are now ready to use the library functionality.
 
+====
+[NOTE]
+You also need to configure your smtp-server before you can send out email. For details, see <<../deployment/config#mail, the configuration page>>
+====
 
 == Functions
 


### PR DESCRIPTION
It will be useful for developers learning to send mail, to find a link to the config together with the api documentation.