### PR TITLE
#12086 Document installUrl allowlist and checksum config

### DIFF
--- a/docs/config/system.adoc
+++ b/docs/config/system.adoc
@@ -727,7 +727,6 @@ installUrl.allowedUrls = https://repo.enonic.com/public/*, https://my.cdn.com/ap
 installUrl.allowedUrls =
 ----
 
-NOTE: Both checks run before the URL is fetched. A URL outside the allowlist or a missing required SHA-512 returns HTTP 409 Conflict. A malformed URL or invalid SHA-512 hex returns HTTP 400 Bad Request.
 
 == Task
 

--- a/docs/config/system.adoc
+++ b/docs/config/system.adoc
@@ -691,6 +691,44 @@ virtual.enabled = false
 virtual.schema.override = false
 ----
 
+[#management-app]
+== Application management API
+
+`com.enonic.xp.server.management.app.cfg`
+
+Configure the security policy for the management Applications API on Port 4848 (`/api/server:app/*`). Currently controls the `/installUrl` endpoint, which installs an application from a remote URL.
+
+.Default configuration
+[source,properties]
+----
+installUrl.allowedUrls = https://*
+installUrl.checksumRequired = true
+----
+
+installUrl.allowedUrls:: Comma-separated wildcard patterns of URLs allowed by `/installUrl`. A trailing `*` matches any suffix; otherwise the pattern is matched exactly as a string prefix. Set to an empty string to disable `/installUrl` entirely. Default: `https://*` (any https URL).
+
+installUrl.checksumRequired:: When `true`, every `/installUrl` request must include a non-empty `sha512` field; the download is rejected if the computed digest does not match. Set to `false` to allow installs without a checksum (not recommended). Default: `true`.
+
+.Restrict installs to the official Enonic public repository
+[source,properties]
+----
+installUrl.allowedUrls = https://repo.enonic.com/public/*
+----
+
+.Allow several explicit hosts
+[source,properties]
+----
+installUrl.allowedUrls = https://repo.enonic.com/public/*, https://my.cdn.com/apps/*
+----
+
+.Disable /installUrl entirely (uploads via /install are unaffected)
+[source,properties]
+----
+installUrl.allowedUrls =
+----
+
+NOTE: Both checks run before the URL is fetched. A URL outside the allowlist or a missing required SHA-512 returns HTTP 409 Conflict. A malformed URL or invalid SHA-512 hex returns HTTP 400 Bad Request.
+
 == Task
 
 `com.enonic.xp.task.cfg`

--- a/docs/endpoints/management.adoc
+++ b/docs/endpoints/management.adoc
@@ -628,6 +628,8 @@ POST app/install
 
 Installs an application from url on all nodes.
 
+The URL must match a pattern configured in the <<../config/system#management-app, Application management API config>>, and a SHA-512 checksum is required by default. Requests violating either policy are rejected with `409 Conflict` before any data is fetched.
+
 .Url
 POST app/installUrl
 
@@ -640,11 +642,11 @@ POST app/installUrl
 
 |`URL`
 |String
-|application URL
+|application URL. Must match one of the patterns configured in `installUrl.allowedUrls`.
 
 |`sha512`
 |String
-| Application file SHA-512 checksum. Optional. If provided, and checksum does not match, installation will fail.
+| Application file SHA-512 checksum. Required by default (`installUrl.checksumRequired = true`). If provided and the computed checksum does not match, installation fails.
 |===
 
 .Response


### PR DESCRIPTION
Documents the configuration introduced in https://github.com/enonic/xp/pull/12099 (issue [#12086](https://github.com/enonic/xp/issues/12086)).

## What's new

- New section **Application management API** in `docs/config/system.adoc` covering `com.enonic.xp.server.management.app.cfg` with both policy keys:
  - `installUrl.allowedUrls` — comma-separated wildcard patterns; default `https://*`
  - `installUrl.checksumRequired` — boolean, default `true`
- Several example configurations (restrict to official repo, allow specific hosts, disable entirely).
- Cross-reference from the `POST app/installUrl` endpoint section, noting that the URL must match a configured pattern, that SHA-512 is required by default, and that policy violations return 409 Conflict before any data is fetched.

## Verified against source

- `AppManagementConfig.java` — default `https://*`, `installUrl.checksumRequired = true`
- `ApplicationLoader.java` — allowlist/checksum mismatches throw 409; malformed URL / invalid hex throw 400
- `com.enonic.xp.server.management.app.cfg` — matches documented examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)