### PR TITLE
Document virtual host API locations

### DIFF
--- a/docs/config/cms.adoc
+++ b/docs/config/cms.adoc
@@ -56,6 +56,10 @@ legacy.mediaApiAutoMount.enabled = false
 
 URLs then take the form `+https://cdn.example.com/media:image/…+` - note there is no `+_+` endpoint segment - and `+<site>/_/media:image/…+` is no longer served, so the CDN fetches from XP's matching `+/api/media:image/…+` path. Disabling the auto-mount without a default base URL makes generated URLs use that `+/api/+` form directly.
 
+Mounts are honored per API, so the two media APIs can be split: a site that lists only `media:image` in its descriptor keeps image URLs on the site and gets attachment URLs from the default base URL.
+
+A virtual host may also declare where APIs are served, per mapping - see <<./vhosts#api-locations, API locations>>. A declaration that names a media API explicitly, such as `+portal.apiBaseUrl.media\:image+`, wins over `media.defaultBaseUrl`, which in turn wins over a declaration covering all APIs.
+
 Sites rendered inside an admin tool are the exception: Content Studio's preview and edit modes keep media anchored to the admin tool's own endpoint, so URLs stay inside the authenticated session.
 
 [#image]

--- a/docs/config/cms.adoc
+++ b/docs/config/cms.adoc
@@ -56,7 +56,7 @@ legacy.mediaApiAutoMount.enabled = false
 
 URLs then take the form `+https://cdn.example.com/media:image/…+` - note there is no `+_+` endpoint segment - and `+<site>/_/media:image/…+` is no longer served, so the CDN fetches from XP's matching `+/api/media:image/…+` path. Disabling the auto-mount without a default base URL makes generated URLs use that `+/api/+` form directly.
 
-Mounts are honored per API, so the two media APIs can be split: a site that lists only `media:image` in its descriptor keeps image URLs on the site and gets attachment URLs from the default base URL.
+Mounts are honored per API, so the two media APIs can be split: a site that lists only `media:image` in its descriptor keeps image URLs on the site and gets attachment URLs from the default media base URL.
 
 A virtual host may also declare where APIs are served, per mapping - see <<./vhosts#api-locations, API locations>>. A declaration that names a media API explicitly, such as `+portal.apiBaseUrl.media\:image+`, wins over `media.defaultBaseUrl`, which in turn wins over a declaration covering all APIs.
 

--- a/docs/config/cms.adoc
+++ b/docs/config/cms.adoc
@@ -58,7 +58,7 @@ URLs then take the form `+https://cdn.example.com/media:image/…+` - note there
 
 Mounts are honored per API, so the two media APIs can be split: a site that lists only `media:image` in its descriptor keeps image URLs on the site and gets attachment URLs from the default media base URL.
 
-A virtual host may also declare where APIs are served, per mapping - see <<./vhosts#api-locations, API locations>>. A declaration that names a media API explicitly, such as `+portal.apiBaseUrl.media\:image+`, wins over `media.defaultBaseUrl`, which in turn wins over a declaration covering all APIs.
+A virtual host may also declare where APIs are served, as part of its <<./vhosts#virtual-host-context, context>> - see <<./vhosts#api-locations, API locations>>. A declaration that names a media API explicitly, such as `+portal.apiBaseUrl.media\:image+`, wins over `media.defaultBaseUrl`, which in turn wins over a declaration covering all APIs.
 
 Sites rendered inside an admin tool are the exception: Content Studio's preview and edit modes keep media anchored to the admin tool's own endpoint, so URLs stay inside the authenticated session.
 

--- a/docs/config/vhosts.adoc
+++ b/docs/config/vhosts.adoc
@@ -157,6 +157,35 @@ mapping.adm.com.enonic.xp.repository.RepositoryId = com.enonic.cms.repository.my
 mapping.adm.com.enonic.xp.branch.Branch = master
 ----
 
+[#api-locations]
+=== API locations
+
+image:xp-8010.svg[XP 8.1.0,opts=inline] APIs may be served from somewhere other than the address a request arrives on: a dedicated API host, a shorter path, or a media host. The context of a virtual host mapping declares where, for requests it matches:
+
+[source,properties]
+----
+mapping.example.host = www.example.com
+mapping.example.source = /
+mapping.example.target = /site/myproject/master/mysite
+mapping.example.context.portal.apiBaseUrl = https://apis.example.com <1>
+mapping.example.context.portal.apiBaseUrl.media\:image = https://images.example.com <2>
+----
+
+<1> Root of the full API set. The API descriptor is appended, so an URL for `com.enonic.app.myapp:myapi` becomes `https://apis.example.com/com.enonic.app.myapp:myapi`.
+<2> Root of a single API, used as it is - nothing is appended. Note the escaped colon: the configuration file is read as a properties file, where an unescaped colon ends the key.
+
+Values are used verbatim and decide the URL form themselves - another host, a path on the same host, or a root-relative path - so an API can be exposed anywhere, including on a host that serves nothing else.
+
+NOTE: The mapping context is one way to declare API locations, not the only one. The entries become attributes of the context the request runs in, so an application can declare them for its own code as well, in a task or a controller.
+
+Declarations are consulted in order of how specifically they name an API, so exposing APIs somewhere does not silently move APIs that are configured elsewhere:
+
+. `portal.apiBaseUrl.<application>:<api>` - names that API.
+. <<./cms#media_base_url, media.defaultBaseUrl>> - names the media APIs.
+. `portal.apiBaseUrl` - names any API.
+
+An API mounted on the site, webapp or admin tool that serves the request keeps its URL under that mount's `_` endpoint; the declared locations apply to APIs that are addressed from elsewhere.
+
 == Examples
 
 "Example Inc", the owner of "example.com" just finished building their new site.

--- a/docs/config/vhosts.adoc
+++ b/docs/config/vhosts.adoc
@@ -176,8 +176,6 @@ mapping.example.context.portal.apiBaseUrl.media\:image = https://images.example.
 
 Values are used verbatim and decide the URL form themselves - another host, a path on the same host, or a root-relative path - so an API can be exposed anywhere, including on a host that serves nothing else.
 
-NOTE: The mapping context is one way to declare API locations, not the only one. The entries become attributes of the context the request runs in, so an application can declare them for its own code as well, in a task or a controller.
-
 Declarations are consulted in order of how specifically they name an API, so exposing APIs somewhere does not silently move APIs that are configured elsewhere:
 
 . `portal.apiBaseUrl.<application>:<api>` - names that API.


### PR DESCRIPTION
Documents the `context.portal.apiBaseUrl` declarations from https://github.com/enonic/xp/pull/12249.

## Virtual hosts page

New `API locations` section, added as a subsection of `Virtual Host Context` since these are context attributes. Covers:

- the bulk form (`context.portal.apiBaseUrl`, API descriptor appended) and the single-API form (`context.portal.apiBaseUrl.media\:image`, used verbatim)
- the escaped colon — the config is read as a properties file, where an unescaped colon ends the key
- the specificity order, and the reason it exists — exposing APIs somewhere should not silently move APIs configured elsewhere
- that an API mounted on the site/webapp/admin tool serving the request keeps its URL under that mount's `_` endpoint

## CMS configuration page

The media keys themselves (`media.defaultBaseUrl`, `legacy.mediaApiAutoMount.enabled`) were already documented in #593, so this only adds what interacts with the new section:

- a cross-reference to `API locations` and to the virtual host context feature the declarations belong to, stating the precedence from the media reader's direction — an explicit `portal.apiBaseUrl.media\:image` beats `media.defaultBaseUrl` beats a catch-all declaration
- that mounts are honored per API, so a site listing only `media:image` in its descriptor keeps image URLs on the site and gets attachment URLs from the default media base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)