### PR TITLE
`should` docs are wrong when combined with `must` or `filter` #596

### DIFF
--- a/docs/storage/dsl.adoc
+++ b/docs/storage/dsl.adoc
@@ -671,8 +671,19 @@ All expressions must evaluate to true to include a node in the result.
 ----
 
 ===== should
+[[should]]
 
-One or more expressions must evaluate to true to include a node in the result.
+Expressions in `should` raise the relevance score of the nodes matching them.
+Whether at least one of them must also match for a node to be included depends on what else the `boolean` query contains:
+
+`should` without `must` or `filter`:: At least one expression must evaluate to true for a node to be included.
+`mustNot` does not change this — `should` still requires one match.
+
+`should` together with `must` or `filter`:: The expressions become *optional* and only contribute to the score.
+Every node matching `must` or `filter` is included, whether or not it matches any `should` expression.
+
+IMPORTANT: In the second case `should` never removes nodes from the result.
+This makes `must` (or `filter`) combined with `should` the way to raise the score of a subset of the results without narrowing them.
 
 .'_path' OR 'displayName' must evaluate to true.
 [source,json]
@@ -698,6 +709,45 @@ One or more expressions must evaluate to true to include a node in the result.
 }
 
 ----
+
+.'must' selects the nodes, 'should' only boosts some of them
+[source,json]
+----
+{
+  "boolean": {
+    "must": {
+      "fulltext": {
+        "fields": [
+          "displayName"
+        ],
+        "query": "fisk",
+        "operator": "AND"
+      }
+    },
+    "should": [
+      {
+        "term": {
+          "field": "category",
+          "value": "recipe",
+          "boost": 2
+        }
+      },
+      {
+        "term": {
+          "field": "category",
+          "value": "restaurant",
+          "boost": 4
+        }
+      }
+    ]
+  }
+}
+----
+Every node matching the `fulltext` expression is returned.
+Nodes in the `recipe` and `restaurant` categories are ranked higher, `restaurant` more than `recipe`.
+
+TIP: Do not repeat the selecting expression inside `should` to boost a subset of the results.
+Its score would then be counted twice, which makes the effect of the <<expression_boost, boost>> values hard to predict.
 
 ===== mustNot
 


### PR DESCRIPTION
Fixes https://github.com/enonic/doc-platform/issues/596

## Problem

The `should` section claimed:

> One or more expressions must evaluate to true to include a node in the result.

That is only true when `should` is used **alone**. With a `must` or a `filter` in the same `boolean` query, `should` is purely score-contributing and excludes nothing. XP never sets `minimum_should_match` — `BooleanQueryBuilder` passes the clauses straight to Elasticsearch — so the behaviour is Elasticsearch's default: `1` with no `must`/`filter`, `0` otherwise.

The practical cost of the wrong text: customers who want to boost a subset build `should(S)` + `should(S AND T)` instead of `must(S)` + `should(T)`, which counts the score of `S` twice and makes the boost values untunable.

## Changes

- Split the description into the two cases (`should` alone vs. with `must`/`filter`).
- State that `filter` relaxes `should` the same way `must` does, and that `mustNot` does not.
- Add an example of the intended pattern: `must` selects the nodes, `should` only boosts some of them.
- Add a TIP against repeating the selecting expression inside `should`.
- Add a `[[should]]` anchor, matching `[[must]]`.

## Verification

Not taken from the Elasticsearch docs — XP 7.16 runs Elasticsearch 2.4.6, whose documentation is far less explicit than 8.x on this point. Every claim was verified against a live embedded Elasticsearch with a new integration test in `enonic/xp` (`FindNodesByQueryCommandTest_dsl_boolean_should`, 5 tests):

| Query | Result |
|---|---|
| `must(S)` + `should(T)`, `T` matches part of the set | nodes failing `T` still returned; `T` only raises their score (2.13 vs 0.12) |
| `must(S)` + `should(T)`, `T` matches nothing | `must` result set unchanged |
| `filter(S)` + `should(T)` | same as `must` |
| `should(T1)` + `should(T2)` alone | nodes matching neither are excluded |
| `mustNot(X)` + `should(T)` | `should` still requires one match |

Reported by Christian Westgaard, who asked for confirmation of exactly this behaviour before restructuring the Explorer search queries.
